### PR TITLE
Upgrade PyYAML dependency from 6 to 6.0.1

### DIFF
--- a/Formula/i2cssh.rb
+++ b/Formula/i2cssh.rb
@@ -29,7 +29,7 @@ class I2cssh < Formula
   end
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.1.tar.gz"
+    url "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
     sha256 "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
   end
 

--- a/Formula/i2cssh.rb
+++ b/Formula/i2cssh.rb
@@ -29,8 +29,8 @@ class I2cssh < Formula
   end
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz"
-    sha256 "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
+    url "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.1.tar.gz"
+    sha256 "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
   end
 
   resource "websockets" do


### PR DESCRIPTION
Fix Installation issues #126

Cython 3.0+ is causing PyYAML install failure on Apple arm64.
https://github.com/yaml/pyyaml/commit/ae08bdc82b4ddfcd2b93c8aedcd1963766c3307d